### PR TITLE
Add missing encodings

### DIFF
--- a/src/core/System/Encodings/EncodingsCatalog.cs
+++ b/src/core/System/Encodings/EncodingsCatalog.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+
+namespace itextsharp.System.Encodings
+{
+    public static class EncodingsCatalog
+    {
+        static EncodingsCatalog()
+        {
+#if !NET40 && !NET45
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
+
+        public static Encoding GetEncoding(int codepage)
+        {
+            return Encoding.GetEncoding(codepage);
+        }
+
+        public static Encoding GetEncoding(string name)
+        {
+            return Encoding.GetEncoding(name);
+        }
+    }
+}

--- a/src/core/System/util/Properties.cs
+++ b/src/core/System/util/Properties.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.IO;
 using System.Collections;
+using itextsharp.System.Encodings;
 
 namespace System.util
 {
@@ -71,7 +72,7 @@ namespace System.util
         }
 
         public void Load(Stream inStream) {
-            StreamReader inp = new StreamReader(inStream, Encoding.GetEncoding(1252));
+            StreamReader inp = new StreamReader(inStream, EncodingsCatalog.GetEncoding(1252));
             while (true) {
                 // Get next line
                 String line = inp.ReadLine();

--- a/src/core/iTextSharp/text/pdf/BarcodeDatamatrix.cs
+++ b/src/core/iTextSharp/text/pdf/BarcodeDatamatrix.cs
@@ -2,6 +2,8 @@ using System;
 using iTextSharp.text;
 using iTextSharp.text.pdf.codec;
 using System.Collections;
+using itextsharp.System.Encodings;
+
 /*
  * $Id: BarcodeDatamatrix.cs,v 1.3 2007/05/21 10:56:38 psoares33 Exp $
  *
@@ -673,7 +675,7 @@ namespace iTextSharp.text.pdf {
         * @throws java.io.UnsupportedEncodingException on error
         */
         public int Generate(String text) {
-            byte[] t = System.Text.Encoding.GetEncoding(1252).GetBytes(text);
+            byte[] t = EncodingsCatalog.GetEncoding(1252).GetBytes(text);
             return Generate(t, 0, t.Length);
         }
         

--- a/src/core/iTextSharp/text/pdf/FdfReader.cs
+++ b/src/core/iTextSharp/text/pdf/FdfReader.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Collections;
 using System.Net;
 using System.IO;
+using itextsharp.System.Encodings;
 
 /*
  * Copyright 2003 by Paulo Soares.
@@ -190,13 +191,13 @@ namespace iTextSharp.text.pdf {
                     return vs.ToUnicodeString();
                 try {
                     if (encoding.Equals(PdfName.SHIFT_JIS))
-                        return Encoding.GetEncoding(932).GetString(b);
+                        return EncodingsCatalog.GetEncoding(932).GetString(b);
                     else if (encoding.Equals(PdfName.UHC))
-                        return Encoding.GetEncoding(949).GetString(b);
+                        return EncodingsCatalog.GetEncoding(949).GetString(b);
                     else if (encoding.Equals(PdfName.GBK))
-                        return Encoding.GetEncoding(936).GetString(b);
+                        return EncodingsCatalog.GetEncoding(936).GetString(b);
                     else if (encoding.Equals(PdfName.BIGFIVE))
-                        return Encoding.GetEncoding(950).GetString(b);
+                        return EncodingsCatalog.GetEncoding(950).GetString(b);
                 }
                 catch  {
                 }

--- a/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
+++ b/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Text;
 using System.Globalization;
 using System.IO;
+using itextsharp.System.Encodings;
 using Org.BouncyCastle.X509;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.Cms;
@@ -933,7 +934,7 @@ namespace iTextSharp.text.pdf {
         
         private static String GetStringFromGeneralName(Asn1Object names) {
             DerTaggedObject taggedObject = (DerTaggedObject) names ;
-            return Encoding.GetEncoding(1252).GetString(Asn1OctetString.GetInstance(taggedObject, false).GetOctets());
+            return EncodingsCatalog.GetEncoding(1252).GetString(Asn1OctetString.GetInstance(taggedObject, false).GetOctets());
         }
 
         /**

--- a/src/core/iTextSharp/text/pdf/Pfm2afm.cs
+++ b/src/core/iTextSharp/text/pdf/Pfm2afm.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Text;
+using itextsharp.System.Encodings;
+
 /*
  * Copyright 2005 by Paulo Soares.
  *
@@ -152,7 +154,7 @@ namespace iTextSharp.text.pdf {
         /** Creates a new instance of Pfm2afm */
         private Pfm2afm(RandomAccessFileOrArray inp, Stream outp) {
             this.inp = inp;
-            encoding = Encoding.GetEncoding(1252);
+            encoding = EncodingsCatalog.GetEncoding(1252);
             this.outp = new StreamWriter(outp, encoding);
         }
         

--- a/src/core/iTextSharp/text/pdf/TrueTypeFont.cs
+++ b/src/core/iTextSharp/text/pdf/TrueTypeFont.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Collections;
-
+using itextsharp.System.Encodings;
 using iTextSharp.text;
 
 /*
@@ -696,7 +696,7 @@ namespace iTextSharp.text.pdf {
         protected string ReadStandardString(int length) {
             byte[] buf = new byte[length];
             rf.ReadFully(buf);
-            return System.Text.Encoding.GetEncoding(1252).GetString(buf);
+            return EncodingsCatalog.GetEncoding(1252).GetString(buf);
         }
     
         /** Reads a Unicode <CODE>string</CODE> from the font file. Each character is

--- a/src/core/iTextSharp/text/pdf/TrueTypeFontSubSet.cs
+++ b/src/core/iTextSharp/text/pdf/TrueTypeFontSubSet.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Collections;
-
+using itextsharp.System.Encodings;
 using iTextSharp.text;
 
 /*
@@ -383,7 +383,7 @@ namespace iTextSharp.text.pdf {
         protected string ReadStandardString(int length) {
             byte[] buf = new byte[length];
             rf.ReadFully(buf);
-            return System.Text.Encoding.GetEncoding(1252).GetString(buf);
+            return EncodingsCatalog.GetEncoding(1252).GetString(buf);
         }
     
         protected void WriteFontShort(int n) {

--- a/src/core/iTextSharp/text/pdf/codec/wmf/MetaDo.cs
+++ b/src/core/iTextSharp/text/pdf/codec/wmf/MetaDo.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using iTextSharp.text;
 using System.Collections;
+using itextsharp.System.Encodings;
 
 /*
  * $Id: MetaDo.cs,v 1.4 2008/05/13 11:25:36 psoares33 Exp $
@@ -471,7 +472,7 @@ namespace iTextSharp.text.pdf.codec.wmf
                     }
                     string s;
                     try {
-                        s = System.Text.Encoding.GetEncoding(1252).GetString(text, 0, k);
+                        s = EncodingsCatalog.GetEncoding(1252).GetString(text, 0, k);
                     }
                     catch  {
                         s = System.Text.ASCIIEncoding.ASCII.GetString(text, 0, k);
@@ -492,7 +493,7 @@ namespace iTextSharp.text.pdf.codec.wmf
                     }
                     string s;
                     try {
-                        s = System.Text.Encoding.GetEncoding(1252).GetString(text, 0, k);
+                        s = EncodingsCatalog.GetEncoding(1252).GetString(text, 0, k);
                     }
                     catch {
                         s = System.Text.ASCIIEncoding.ASCII.GetString(text, 0, k);

--- a/src/core/iTextSharp/text/pdf/codec/wmf/MetaFont.cs
+++ b/src/core/iTextSharp/text/pdf/codec/wmf/MetaFont.cs
@@ -1,4 +1,5 @@
 using System;
+using itextsharp.System.Encodings;
 
 /*
  * $Id: MetaFont.cs,v 1.7 2008/05/13 11:25:37 psoares33 Exp $
@@ -116,7 +117,7 @@ namespace iTextSharp.text.pdf.codec.wmf {
                 name[k] = (byte)c;
             }
             try {
-                faceName = System.Text.Encoding.GetEncoding(1252).GetString(name, 0, k);
+                faceName = EncodingsCatalog.GetEncoding(1252).GetString(name, 0, k);
             }
             catch {
                 faceName = System.Text.ASCIIEncoding.ASCII.GetString(name, 0, k);

--- a/src/core/iTextSharp/text/xml/simpleparser/IanaEncodings.cs
+++ b/src/core/iTextSharp/text/xml/simpleparser/IanaEncodings.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Text;
+using itextsharp.System.Encodings;
+
 /*
  * $Id: IanaEncodings.cs,v 1.4 2008/05/13 11:26:14 psoares33 Exp $
  * 
@@ -543,9 +545,9 @@ namespace iTextSharp.text.xml.simpleparser {
             if (nameU.Equals("UNICODELITTLE"))
                 return new UnicodeEncoding(false, true);
             if (map.ContainsKey(nameU))
-                return Encoding.GetEncoding((int)map[nameU]);
+                return EncodingsCatalog.GetEncoding((int)map[nameU]);
             else
-                return Encoding.GetEncoding(name);
+                return EncodingsCatalog.GetEncoding(name);
         }
     }
 }

--- a/src/core/iTextSharp/text/xml/simpleparser/SimpleXMLParser.cs
+++ b/src/core/iTextSharp/text/xml/simpleparser/SimpleXMLParser.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using System.Collections;
 using System.Globalization;
+using itextsharp.System.Encodings;
+
 /*
  * Copyright 2003 Paulo Soares
  *
@@ -603,7 +605,7 @@ namespace iTextSharp.text.xml.simpleparser {
                         break;
                     bi.WriteByte((byte)c);
                 }
-                decl = Encoding.GetEncoding(37).GetString(bi.ToArray());//cp037 ebcdic
+                decl = EncodingsCatalog.GetEncoding(37).GetString(bi.ToArray());//cp037 ebcdic
             }
             if (decl != null) {
                 decl = GetDeclaredEncoding(decl);

--- a/src/core/itextsharp.csproj
+++ b/src/core/itextsharp.csproj
@@ -23,4 +23,9 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Encoding.CodePages">
+      <Version>4.7.1</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/core/itextsharp.sln
+++ b/src/core/itextsharp.sln
@@ -1,8 +1,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "itextsharp", "itextsharp.csproj", "{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "itextsharp", "itextsharp.csproj", "{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "itextsharp.Tests", "..\itextsharp.Tests\itextsharp.Tests.csproj", "{6A88E065-F4E4-4FDD-8A40-4D354EBFB0AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,6 +16,10 @@ Global
 		{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A88E065-F4E4-4FDD-8A40-4D354EBFB0AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A88E065-F4E4-4FDD-8A40-4D354EBFB0AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A88E065-F4E4-4FDD-8A40-4D354EBFB0AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A88E065-F4E4-4FDD-8A40-4D354EBFB0AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/itextsharp.Tests/System/Encodings/EncodingsCatalogTests.cs
+++ b/src/itextsharp.Tests/System/Encodings/EncodingsCatalogTests.cs
@@ -9,9 +9,19 @@ namespace itextsharp.Tests.System.Encodings
         [InlineData(932)]
         [InlineData(936)]
         [InlineData(1251)]
-        public void GetEncoding_returnsEncoding(int codepage)
+        public void GetEncodingByCodePage_returnsEncoding(int codepage)
         {
             var encoding = EncodingsCatalog.GetEncoding(codepage);
+            Assert.Equal(codepage, encoding.CodePage);
+        }
+
+        [Theory]
+        [InlineData("Windows-1252")]
+        [InlineData("Shift-JIS")]
+        [InlineData("GB2312")]
+        public void GetEncodingByName_returnsEncoding(string name)
+        {
+            var encoding = EncodingsCatalog.GetEncoding(name);
             Assert.NotNull(encoding);
         }
     }

--- a/src/itextsharp.Tests/System/Encodings/EncodingsCatalogTests.cs
+++ b/src/itextsharp.Tests/System/Encodings/EncodingsCatalogTests.cs
@@ -1,0 +1,18 @@
+﻿using itextsharp.System.Encodings;
+using Xunit;
+
+namespace itextsharp.Tests.System.Encodings
+{
+    public class EncodingsCatalogTests
+    {
+        [Theory]
+        [InlineData(932)]
+        [InlineData(936)]
+        [InlineData(1251)]
+        public void GetEncoding_returnsEncoding(int codepage)
+        {
+            var encoding = EncodingsCatalog.GetEncoding(codepage);
+            Assert.NotNull(encoding);
+        }
+    }
+}

--- a/src/itextsharp.Tests/itextsharp.Tests.csproj
+++ b/src/itextsharp.Tests/itextsharp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\core\itextsharp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds in .net core support for the Windows-1252, Shift-JIS, and GB2312 encodings, which are not available out of the box.

Fixes #2 